### PR TITLE
removing .travis.yml for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: node


### PR DESCRIPTION
We're not leveraging this correctly, removing for now.